### PR TITLE
[skip ci] fix release: enable file glob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  release:
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
@@ -28,4 +28,6 @@ jobs:
         file: 'releases/google_authenticator_extractor*'
         tag: ${{ github.ref }}
         overwrite: true
+        file_glob: true
+
 


### PR DESCRIPTION
Another fix for https://github.com/zhangyuan/google-authenticator-extractor/pull/16